### PR TITLE
Remove unused variable

### DIFF
--- a/keccak.py
+++ b/keccak.py
@@ -184,7 +184,6 @@ class KeccakState(object):
         Mixes in the given bitrate-length string to the state.
         """
         assert len(bb) == self.bitrate_bytes
-        bitrate_lanes = self.bitrate / self.lanew
         
         bb += [0] * bits2bytes(self.b - self.bitrate)
         i = 0


### PR DESCRIPTION
`bitrate_lanes` isn't used anywhere. Removed it to avoid potential confusion.

(GitHub web editor automatically modified the last line, hope that's not a big deal.)